### PR TITLE
doc: explain autogluon training parameters

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -211,6 +211,27 @@ All of the aforementioned model libraries implement gradient boosted decision tr
 * XGBoost: https://xgboost.readthedocs.io/en/stable/#
 * AutoGluon: https://auto.gluon.ai/stable/index.html
 
+### AutoGluon training parameters
+
+The ``AutoGluonTabularRegressor`` exposes many options from
+``autogluon.tabular.TabularPredictor.fit``.  They can be configured through
+``freqai.model_training_parameters``. Common settings include:
+
+* ``time_limit`` – maximum training time in seconds.
+* ``presets`` – AutoGluon preset string or list controlling model quality.
+* ``hyperparameters`` – dictionary defining the model search space.
+* ``eval_metric`` – metric used to select the best models.
+
+Example::
+
+    "freqai": {
+        "model_training_parameters": {
+            "time_limit": 600,
+            "presets": "medium_quality",
+            "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
+        }
+    }
+
 There are also numerous online articles describing and comparing the algorithms. Some relatively lightweight examples would be [CatBoost vs. LightGBM vs. XGBoost — Which is the best algorithm?](https://towardsdatascience.com/catboost-vs-lightgbm-vs-xgboost-c80f40662924#:~:text=In%20CatBoost%2C%20symmetric%20trees%2C%20or,the%20same%20depth%20can%20differ.) and [XGBoost, LightGBM or CatBoost — which boosting algorithm should I use?](https://medium.com/riskified-technology/xgboost-lightgbm-or-catboost-which-boosting-algorithm-should-i-use-e7fda7bb36bc). Keep in mind that the performance of each model is highly dependent on the application and so any reported metrics might not be true for your particular use of the model.
 
 Apart from the models already available in FreqAI, it is also possible to customize and create your own prediction models using the `IFreqaiModel` class. You are encouraged to inherit `fit()`, `train()`, and `predict()` to customize various aspects of the training procedures. You can place custom FreqAI models in `user_data/freqaimodels` - and freqtrade will pick them up from there based on the provided `--freqaimodel` name - which has to correspond to the class name of your custom model.

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -4,6 +4,7 @@ from typing import Any
 from freqtrade.freqai.base_models.BaseRegressionModel import BaseRegressionModel
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +19,22 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
     """
 
     def fit(self, data_dictionary: dict, dk: FreqaiDataKitchen, **kwargs) -> Any:
-        """Train an AutoGluon TabularPredictor."""
+        """Train an AutoGluon TabularPredictor.
+
+        Any argument accepted by :meth:`autogluon.tabular.TabularPredictor.fit`
+        can be provided via ``model_training_parameters`` in the FreqAI config.
+        Common options include ``time_limit`` (seconds to train), ``presets``
+        (predefined training configurations), ``hyperparameters`` (model
+        search space), ``eval_metric`` and ``ag_args_fit``.  Example::
+
+            "freqai": {
+                "model_training_parameters": {
+                    "time_limit": 600,
+                    "presets": "medium_quality",
+                    "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
+                }
+            }
+        """
         try:
             from autogluon.tabular import TabularPredictor
         except ImportError as e:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- detail how to pass AutoGluon TabularPredictor arguments through `model_training_parameters`
- document AutoGluon-specific options in FreqAI configuration guide

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py docs/freqai-configuration.md`


------
https://chatgpt.com/codex/tasks/task_e_68a060afe3448326930be2de18f7e761