### PR TITLE
feat: expose AutoGluon tuning options

### DIFF
--- a/config_examples/config_freqai_autogluon.example.json
+++ b/config_examples/config_freqai_autogluon.example.json
@@ -81,7 +81,15 @@
             "test_size": 0.33,
             "random_state": 1
         },
-        "model_training_parameters": {}
+        "model_training_parameters": {
+            "presets": "medium_quality",
+            "eval_metric": "mean_absolute_error",
+            "hyperparameter_tune_kwargs": {
+                "num_trials": 5,
+                "scheduler": "local",
+                "searcher": "auto"
+            }
+        }
     },
     "bot_name": "",
     "force_entry_enable": true,

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -220,6 +220,7 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 * ``time_limit`` – maximum training time in seconds.
 * ``presets`` – AutoGluon preset string or list controlling model quality.
 * ``hyperparameters`` – dictionary defining the model search space.
+* ``hyperparameter_tune_kwargs`` – options for AutoGluon's hyperparameter tuner.
 * ``eval_metric`` – metric used to select the best models.
 
 Example::
@@ -228,6 +229,12 @@ Example::
         "model_training_parameters": {
             "time_limit": 600,
             "presets": "medium_quality",
+            "eval_metric": "mean_absolute_error",
+            "hyperparameter_tune_kwargs": {
+                "num_trials": 5,
+                "scheduler": "local",
+                "searcher": "auto"
+            },
             "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
         }
     }

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -24,13 +24,20 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
         Any argument accepted by :meth:`autogluon.tabular.TabularPredictor.fit`
         can be provided via ``model_training_parameters`` in the FreqAI config.
         Common options include ``time_limit`` (seconds to train), ``presets``
-        (predefined training configurations), ``hyperparameters`` (model
-        search space), ``eval_metric`` and ``ag_args_fit``.  Example::
+        (predefined training configurations), ``hyperparameters`` (model search
+        space), ``hyperparameter_tune_kwargs`` (search strategy), ``eval_metric``
+        and ``ag_args_fit``.  Example::
 
             "freqai": {
                 "model_training_parameters": {
                     "time_limit": 600,
                     "presets": "medium_quality",
+                    "eval_metric": "mean_absolute_error",
+                    "hyperparameter_tune_kwargs": {
+                        "num_trials": 5,
+                        "scheduler": "local",
+                        "searcher": "auto"
+                    },
                     "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
                 }
             }
@@ -52,5 +59,18 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             tuning_data[dk.label_list[0]] = data_dictionary["test_labels"].squeeze()
 
         predictor = TabularPredictor(label=dk.label_list[0], problem_type="regression")
-        predictor = predictor.fit(train, tuning_data=tuning_data, **self.model_training_parameters)
+
+        train_params = self.model_training_parameters.copy()
+        hyperparameter_tune_kwargs = train_params.pop("hyperparameter_tune_kwargs", None)
+        presets = train_params.pop("presets", None)
+        eval_metric = train_params.pop("eval_metric", None)
+
+        predictor = predictor.fit(
+            train,
+            tuning_data=tuning_data,
+            hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            presets=presets,
+            eval_metric=eval_metric,
+            **train_params,
+        )
         return predictor


### PR DESCRIPTION
## Summary
- pass tuning and metric options from `model_training_parameters` to AutoGluon TabularPredictor
- document `hyperparameter_tune_kwargs`, `presets` and `eval_metric` in FreqAI config examples

## Testing
- `pre-commit run --files config_examples/config_freqai_autogluon.example.json docs/freqai-configuration.md freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py`
- `pytest tests/freqai/test_freqai_autogluon_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0675ab5408326a7e0d87a4b3f3d32