### PR TITLE
Enable GPU-aware AutoGluon training in FreqAI

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -221,6 +221,8 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 * ``presets`` – AutoGluon preset string or list controlling model quality.
 * ``hyperparameters`` – dictionary defining the model search space.
 * ``eval_metric`` – metric used to select the best models.
+* ``num_gpus`` – number of GPUs to use. If not provided, FreqAI will
+  automatically enable one GPU when CUDA is available.
 
 Example::
 
@@ -228,7 +230,8 @@ Example::
         "model_training_parameters": {
             "time_limit": 600,
             "presets": "medium_quality",
-            "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
+            "hyperparameters": {"GBM": {}, "NN_TORCH": {}},
+            "num_gpus": 1
         }
     }
 

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -18,6 +18,33 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
     installed.
     """
 
+    def _configure_gpus(self) -> None:
+        ag_args_fit = self.model_training_parameters.get("ag_args_fit", {})
+        if "ag_args_fit" not in self.model_training_parameters:
+            self.model_training_parameters["ag_args_fit"] = ag_args_fit
+        if "num_gpus" in ag_args_fit:
+            return
+        num_gpus = self.model_training_parameters.pop("num_gpus", None)
+        if num_gpus is None:
+            try:  # pragma: no cover - optional dependency
+                import torch
+            except ImportError:  # pragma: no cover - optional dependency
+                pass
+            else:
+                if torch.cuda.is_available():
+                    num_gpus = 1
+        if num_gpus is None:
+            try:  # pragma: no cover - optional dependency
+                from autogluon.common.utils.resource_utils import get_gpu_count
+            except ImportError:  # pragma: no cover - optional dependency
+                pass
+            else:
+                count = get_gpu_count()
+                if count > 0:
+                    num_gpus = count
+        if num_gpus is not None:
+            ag_args_fit["num_gpus"] = num_gpus
+
     def fit(self, data_dictionary: dict, dk: FreqaiDataKitchen, **kwargs) -> Any:
         """Train an AutoGluon TabularPredictor.
 
@@ -42,6 +69,9 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
                 "AutoGluon is not installed. Install it with "
                 "'pip install autogluon.tabular' to use AutoGluonTabularRegressor."
             ) from e
+
+        # Enable GPU training if available unless configured otherwise
+        self._configure_gpus()
 
         train = data_dictionary["train_features"].copy()
         train[dk.label_list[0]] = data_dictionary["train_labels"].squeeze()


### PR DESCRIPTION
## Summary
- Auto-detect CUDA and pass `num_gpus` to AutoGluonTabularRegressor
- Document `num_gpus` option in FreqAI configuration guide

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py docs/freqai-configuration.md`

------
https://chatgpt.com/codex/tasks/task_e_68a0675bc12c832682d868a438b232c9