### PR TITLE
feat(freqai): allow autogluon bagging and time limit

### DIFF
--- a/config_examples/config_freqai_autogluon.example.json
+++ b/config_examples/config_freqai_autogluon.example.json
@@ -81,7 +81,12 @@
             "test_size": 0.33,
             "random_state": 1
         },
-        "model_training_parameters": {}
+        "model_training_parameters": {
+            "time_limit": 600,
+            "num_bag_folds": 5,
+            "num_bag_sets": 1,
+            "presets": "medium_quality"
+        }
     },
     "bot_name": "",
     "force_entry_enable": true,

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -217,7 +217,9 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 ``autogluon.tabular.TabularPredictor.fit``.  They can be configured through
 ``freqai.model_training_parameters``. Common settings include:
 
-* ``time_limit`` – maximum training time in seconds.
+* ``time_limit`` – maximum training time in seconds (enables early stopping).
+* ``num_bag_folds`` – number of folds for bagging to improve accuracy.
+* ``num_bag_sets`` – number of bagging sets to repeat training.
 * ``presets`` – AutoGluon preset string or list controlling model quality.
 * ``hyperparameters`` – dictionary defining the model search space.
 * ``eval_metric`` – metric used to select the best models.
@@ -227,6 +229,8 @@ Example::
     "freqai": {
         "model_training_parameters": {
             "time_limit": 600,
+            "num_bag_folds": 5,
+            "num_bag_sets": 1,
             "presets": "medium_quality",
             "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
         }

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -23,13 +23,16 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
 
         Any argument accepted by :meth:`autogluon.tabular.TabularPredictor.fit`
         can be provided via ``model_training_parameters`` in the FreqAI config.
-        Common options include ``time_limit`` (seconds to train), ``presets``
-        (predefined training configurations), ``hyperparameters`` (model
-        search space), ``eval_metric`` and ``ag_args_fit``.  Example::
+        Common options include ``time_limit`` (maximum training seconds),
+        ``presets`` (predefined training configurations), ``hyperparameters``
+        (model search space), ``eval_metric``, ``ag_args_fit`` and bagging
+        options like ``num_bag_folds`` and ``num_bag_sets``.  Example::
 
             "freqai": {
                 "model_training_parameters": {
                     "time_limit": 600,
+                    "num_bag_folds": 5,
+                    "num_bag_sets": 1,
                     "presets": "medium_quality",
                     "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
                 }
@@ -52,5 +55,19 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             tuning_data[dk.label_list[0]] = data_dictionary["test_labels"].squeeze()
 
         predictor = TabularPredictor(label=dk.label_list[0], problem_type="regression")
-        predictor = predictor.fit(train, tuning_data=tuning_data, **self.model_training_parameters)
+
+        fit_kwargs = self.model_training_parameters.copy()
+        time_limit = fit_kwargs.pop("time_limit", None)
+        num_bag_folds = fit_kwargs.pop("num_bag_folds", None)
+        num_bag_sets = fit_kwargs.pop("num_bag_sets", None)
+
+        params = {"tuning_data": tuning_data, **fit_kwargs}
+        if time_limit is not None:
+            params["time_limit"] = time_limit
+        if num_bag_folds is not None:
+            params["num_bag_folds"] = num_bag_folds
+        if num_bag_sets is not None:
+            params["num_bag_sets"] = num_bag_sets
+
+        predictor = predictor.fit(train, **params)
         return predictor


### PR DESCRIPTION
## Summary
- expose `num_bag_folds` and `num_bag_sets` to AutoGluonTabularRegressor via `model_training_parameters`
- allow specifying `time_limit` in `model_training_parameters` for early stopping
- document bagging options and update AutoGluon example configuration

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py config_examples/config_freqai_autogluon.example.json docs/freqai-configuration.md`
- `pytest tests/freqai/test_freqai_autogluon_strategy.py::test_freqai_autogluon_strategy_backtest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06760192883268eac1faa669f38b1