### PR TITLE
Expose AutoGluon bagging options

### DIFF
--- a/config_examples/config_freqai_autogluon.example.json
+++ b/config_examples/config_freqai_autogluon.example.json
@@ -82,6 +82,9 @@
             "random_state": 1
         },
         "model_training_parameters": {
+            "time_limit": 600,
+            "num_bag_folds": 3,
+            "num_bag_sets": 2,
             "presets": "medium_quality",
             "eval_metric": "mean_absolute_error",
             "hyperparameter_tune_kwargs": {

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -218,6 +218,8 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 ``freqai.model_training_parameters``. Common settings include:
 
 * ``time_limit`` – maximum training time in seconds.
+* ``num_bag_folds`` – number of folds used for bagging.
+* ``num_bag_sets`` – number of bagging repeats.
 * ``presets`` – AutoGluon preset string or list controlling model quality.
 * ``hyperparameters`` – dictionary defining the model search space.
 * ``hyperparameter_tune_kwargs`` – options for AutoGluon's hyperparameter tuner.
@@ -228,6 +230,8 @@ Example::
     "freqai": {
         "model_training_parameters": {
             "time_limit": 600,
+            "num_bag_folds": 3,
+            "num_bag_sets": 2,
             "presets": "medium_quality",
             "eval_metric": "mean_absolute_error",
             "hyperparameter_tune_kwargs": {

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -23,7 +23,8 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
 
         Any argument accepted by :meth:`autogluon.tabular.TabularPredictor.fit`
         can be provided via ``model_training_parameters`` in the FreqAI config.
-        Common options include ``time_limit`` (seconds to train), ``presets``
+        Common options include ``time_limit`` (seconds to train), ``num_bag_folds``
+        (bagging folds), ``num_bag_sets`` (repeats of bagging), ``presets``
         (predefined training configurations), ``hyperparameters`` (model search
         space), ``hyperparameter_tune_kwargs`` (search strategy), ``eval_metric``
         and ``ag_args_fit``.  Example::
@@ -31,6 +32,8 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             "freqai": {
                 "model_training_parameters": {
                     "time_limit": 600,
+                    "num_bag_folds": 3,
+                    "num_bag_sets": 2,
                     "presets": "medium_quality",
                     "eval_metric": "mean_absolute_error",
                     "hyperparameter_tune_kwargs": {
@@ -64,6 +67,9 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
         hyperparameter_tune_kwargs = train_params.pop("hyperparameter_tune_kwargs", None)
         presets = train_params.pop("presets", None)
         eval_metric = train_params.pop("eval_metric", None)
+        num_bag_folds = train_params.pop("num_bag_folds", None)
+        num_bag_sets = train_params.pop("num_bag_sets", None)
+        time_limit = train_params.pop("time_limit", None)
 
         predictor = predictor.fit(
             train,
@@ -71,6 +77,9 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             presets=presets,
             eval_metric=eval_metric,
+            num_bag_folds=num_bag_folds,
+            num_bag_sets=num_bag_sets,
+            time_limit=time_limit,
             **train_params,
         )
         return predictor


### PR DESCRIPTION
## Summary
- forward `num_bag_folds`, `num_bag_sets`, and `time_limit` to AutoGluon TabularPredictor
- document new AutoGluon bagging settings and show example config

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py docs/freqai-configuration.md config_examples/config_freqai_autogluon.example.json`
- `pytest tests/freqai/test_freqai_autogluon_strategy.py::test_freqai_autogluon_strategy_backtest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06a7aa26883269e3a0b92f768da90