### PR TITLE
docs: clarify AutoGluon tuning parameters

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -223,6 +223,9 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 * ``hyperparameter_tune_kwargs`` – options for AutoGluon's hyperparameter tuner.
 * ``eval_metric`` – metric used to select the best models.
 
+These values are forwarded directly to AutoGluon's ``TabularPredictor.fit``
+method.
+
 Example::
 
     "freqai": {

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -61,6 +61,7 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
         predictor = TabularPredictor(label=dk.label_list[0], problem_type="regression")
 
         train_params = self.model_training_parameters.copy()
+        # Pull tuning related settings so they can be forwarded explicitly
         hyperparameter_tune_kwargs = train_params.pop("hyperparameter_tune_kwargs", None)
         presets = train_params.pop("presets", None)
         eval_metric = train_params.pop("eval_metric", None)


### PR DESCRIPTION
## Summary
- Clarify that tuning related settings like `hyperparameter_tune_kwargs`, `presets`, and `eval_metric` are forwarded to AutoGluon's `TabularPredictor.fit`
- Document that these options are passed straight through to AutoGluon

## Testing
- `pytest tests/freqai/test_freqai_autogluon_strategy.py::test_freqai_autogluon_strategy_backtest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a06a785ba48326b8aeed99a1cd09b0