### PR TITLE
feat: make AutoGluon GPU usage configurable

### DIFF
--- a/config_examples/config_freqai.example.json
+++ b/config_examples/config_freqai.example.json
@@ -80,7 +80,9 @@
             "test_size": 0.33,
             "random_state": 1
         },
-        "model_training_parameters": {}
+        "model_training_parameters": {
+            "num_gpus": 1
+        }
     },
     "bot_name": "",
     "force_entry_enable": true,

--- a/config_examples/config_freqai_autogluon.example.json
+++ b/config_examples/config_freqai_autogluon.example.json
@@ -84,6 +84,7 @@
         "model_training_parameters": {
             "presets": "medium_quality",
             "eval_metric": "mean_absolute_error",
+            "num_gpus": 1,
             "hyperparameter_tune_kwargs": {
                 "num_trials": 5,
                 "scheduler": "local",

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -222,6 +222,7 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 * ``hyperparameters`` – dictionary defining the model search space.
 * ``hyperparameter_tune_kwargs`` – options for AutoGluon's hyperparameter tuner.
 * ``eval_metric`` – metric used to select the best models.
+* ``num_gpus`` – number of GPUs to use. Set to ``0`` to force CPU training.
 
 Example::
 
@@ -230,6 +231,7 @@ Example::
             "time_limit": 600,
             "presets": "medium_quality",
             "eval_metric": "mean_absolute_error",
+            "num_gpus": 1,
             "hyperparameter_tune_kwargs": {
                 "num_trials": 5,
                 "scheduler": "local",

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -43,6 +43,7 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             }
         """
         try:
+            from autogluon.common.utils.resource_utils import get_gpu_count
             from autogluon.tabular import TabularPredictor
         except ImportError as e:  # pragma: no cover - optional dependency
             raise ImportError(
@@ -61,6 +62,30 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
         predictor = TabularPredictor(label=dk.label_list[0], problem_type="regression")
 
         train_params = self.model_training_parameters.copy()
+
+        num_gpus = train_params.pop("num_gpus", None)
+
+        gpu_available = False
+        try:  # pragma: no cover - torch optional
+            import torch
+
+            gpu_available = torch.cuda.is_available()
+        except Exception:  # pragma: no cover - fallback to autogluon utility
+            try:
+                gpu_available = get_gpu_count() > 0
+            except Exception:  # pragma: no cover
+                gpu_available = False
+
+        if num_gpus is None:
+            num_gpus = 1 if gpu_available else 0
+
+        if num_gpus > 0 and gpu_available:
+            ag_args_fit = train_params.get("ag_args_fit", {})
+            ag_args_fit.setdefault("num_gpus", num_gpus)
+            train_params["ag_args_fit"] = ag_args_fit
+        elif num_gpus > 0:
+            logger.warning("num_gpus > 0 but no CUDA device detected - training will use CPU.")
+
         hyperparameter_tune_kwargs = train_params.pop("hyperparameter_tune_kwargs", None)
         presets = train_params.pop("presets", None)
         eval_metric = train_params.pop("eval_metric", None)


### PR DESCRIPTION
## Summary
- detect CUDA availability for AutoGluon models and configure GPU usage via `num_gpus`
- document new `num_gpus` option for FreqAI models
- add `num_gpus` to FreqAI configuration examples

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py docs/freqai-configuration.md config_examples/config_freqai.example.json config_examples/config_freqai_autogluon.example.json`
- `pytest tests/freqai` *(fails: ModuleNotFoundError: No module named 'datasieve' and other optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a06a78b1108326ab68ae86b3e927f6