### PR TITLE
Add configurable GPU usage for AutoGluon models

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -224,6 +224,8 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 * ``hyperparameters`` – dictionary defining the model search space.
 * ``hyperparameter_tune_kwargs`` – options for AutoGluon's hyperparameter tuner.
 * ``eval_metric`` – metric used to select the best models.
+* ``num_gpus`` – number of GPUs AutoGluon should use (defaults to ``1`` if
+  CUDA is available, otherwise ``0``).
 
 These values are forwarded directly to AutoGluon's ``TabularPredictor.fit``
 method.
@@ -237,6 +239,7 @@ Example::
             "num_bag_sets": 2,
             "presets": "medium_quality",
             "eval_metric": "mean_absolute_error",
+            "num_gpus": 1,
             "hyperparameter_tune_kwargs": {
                 "num_trials": 5,
                 "scheduler": "local",
@@ -258,7 +261,8 @@ Example::
     "freqai": {
         "model_training_parameters": {
             "freq": "1h",
-            "time_limit": 600
+            "time_limit": 600,
+            "num_gpus": 1
         }
     }
 

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -1,6 +1,12 @@
 import logging
 from typing import Any
 
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None
+
 from freqtrade.freqai.base_models.BaseRegressionModel import BaseRegressionModel
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 
@@ -71,6 +77,12 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
         num_bag_folds = train_params.pop("num_bag_folds", None)
         num_bag_sets = train_params.pop("num_bag_sets", None)
         time_limit = train_params.pop("time_limit", None)
+        num_gpus = train_params.pop("num_gpus", 1 if torch and torch.cuda.is_available() else 0)
+        if num_gpus > 0 and not (torch and torch.cuda.is_available()):
+            logger.warning("num_gpus requested but CUDA is not available. Using CPU")
+            num_gpus = 0
+        ag_args_fit = train_params.pop("ag_args_fit", {})
+        ag_args_fit["num_gpus"] = num_gpus
 
         predictor = predictor.fit(
             train,
@@ -81,6 +93,7 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             num_bag_folds=num_bag_folds,
             num_bag_sets=num_bag_sets,
             time_limit=time_limit,
+            ag_args_fit=ag_args_fit,
             **train_params,
         )
         return predictor

--- a/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
@@ -1,6 +1,12 @@
 import logging
 from typing import Any
 
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None
+
 import numpy as np
 import pandas as pd
 
@@ -35,7 +41,14 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
                 "'pip install autogluon.timeseries' to use AutoGluonTimeSeriesPredictor."
             ) from e
 
-        freq = self.model_training_parameters.pop("freq", None)
+        train_params = self.model_training_parameters.copy()
+        freq = train_params.pop("freq", None)
+        num_gpus = train_params.pop("num_gpus", 1 if torch and torch.cuda.is_available() else 0)
+        if num_gpus > 0 and not (torch and torch.cuda.is_available()):
+            logger.warning("num_gpus requested but CUDA is not available. Using CPU")
+            num_gpus = 0
+        ag_args_fit = train_params.pop("ag_args_fit", {})
+        ag_args_fit["num_gpus"] = num_gpus
 
         train = data_dictionary["train_features"].copy()
         train["target"] = data_dictionary["train_labels"].squeeze()
@@ -77,7 +90,10 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
             freq=freq,
         )
         predictor = predictor.fit(
-            self.train_ts, tuning_data=tuning_ts, **self.model_training_parameters
+            self.train_ts,
+            tuning_data=tuning_ts,
+            ag_args_fit=ag_args_fit,
+            **train_params,
         )
         return predictor
 


### PR DESCRIPTION
## Summary
- allow configuring num_gpus for AutoGluon predictors
- pass `ag_args_fit` with detected GPU count
- document `num_gpus` in FreqAI configuration

## Testing
- `pre-commit run --files docs/freqai-configuration.md freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py`

------
https://chatgpt.com/codex/tasks/task_e_68a06d770464832697629a2428689d85