### PR TITLE
feat(freqai): expose AutoGluon fit options

### DIFF
--- a/config_examples/config_freqai_autogluon.example.json
+++ b/config_examples/config_freqai_autogluon.example.json
@@ -91,7 +91,8 @@
                 "num_trials": 5,
                 "scheduler": "local",
                 "searcher": "auto"
-            }
+            },
+            "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
         }
     },
     "bot_name": "",

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -226,7 +226,8 @@ The ``AutoGluonTabularRegressor`` exposes many options from
 * ``eval_metric`` – metric used to select the best models.
 
 These values are forwarded directly to AutoGluon's ``TabularPredictor.fit``
-method.
+method (and to ``TimeSeriesPredictor.fit`` when using
+``AutoGluonTimeSeriesPredictor``).
 
 Example::
 
@@ -250,15 +251,24 @@ Example::
 
 The ``AutoGluonTimeSeriesPredictor`` wraps AutoGluon's
 ``TimeSeriesPredictor`` and automatically converts the data into a
-``TimeSeriesDataFrame``.  In addition to the common settings above, it accepts
-``freq`` to specify the frequency of the time index.
+``TimeSeriesDataFrame``.  In addition to the common settings above, it forwards
+``time_limit``, ``presets``, ``hyperparameter_tune_kwargs`` and ``eval_metric``
+to ``TimeSeriesPredictor.fit``.  It also accepts ``freq`` to specify the
+frequency of the time index.
 
 Example::
 
     "freqai": {
         "model_training_parameters": {
             "freq": "1h",
-            "time_limit": 600
+            "time_limit": 600,
+            "presets": "medium_quality",
+            "eval_metric": "mean_absolute_error",
+            "hyperparameter_tune_kwargs": {
+                "num_trials": 5,
+                "scheduler": "local",
+                "searcher": "auto"
+            }
         }
     }
 

--- a/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
@@ -35,7 +35,12 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
                 "'pip install autogluon.timeseries' to use AutoGluonTimeSeriesPredictor."
             ) from e
 
-        freq = self.model_training_parameters.pop("freq", None)
+        train_params = self.model_training_parameters.copy()
+        freq = train_params.pop("freq", None)
+        hyperparameter_tune_kwargs = train_params.pop("hyperparameter_tune_kwargs", None)
+        presets = train_params.pop("presets", None)
+        eval_metric = train_params.pop("eval_metric", None)
+        time_limit = train_params.pop("time_limit", None)
 
         train = data_dictionary["train_features"].copy()
         train["target"] = data_dictionary["train_labels"].squeeze()
@@ -77,7 +82,13 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
             freq=freq,
         )
         predictor = predictor.fit(
-            self.train_ts, tuning_data=tuning_ts, **self.model_training_parameters
+            self.train_ts,
+            tuning_data=tuning_ts,
+            hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            presets=presets,
+            eval_metric=eval_metric,
+            time_limit=time_limit,
+            **train_params,
         )
         return predictor
 


### PR DESCRIPTION
## Summary
- allow AutoGluonTimeSeriesPredictor to forward presets, hyperparameter tuning args, time limit and eval metric to AutoGluon
- document new AutoGluon training parameters and update config example

## Testing
- `pytest tests/freqai/test_freqai_autogluon_strategy.py tests/freqai/test_freqai_autogluon_timeseries_strategy.py`

------
https://chatgpt.com/codex/tasks/task_e_68a06d78bcc483268dbc7642fb9281a4