### PR TITLE
Add configurable feature engineering pipeline for FreqAI

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -26,6 +26,24 @@ FreqAI is configured through the typical [Freqtrade config file](configuration.m
         },
         "data_split_parameters" : {
             "test_size": 0.25
+    }
+}
+```
+
+A feature engineering pipeline can optionally be enabled via `freqai.feature_engineering`.
+The pipeline runs before the train/test split and currently supports the
+[`tsfresh`](https://tsfresh.readthedocs.io/) and
+[`featuretools`](https://featuretools.alteryx.com/) libraries. An example
+configuration looks like this:
+
+```json
+    "freqai": {
+        ...,
+        "feature_engineering": {
+            "library": "tsfresh",
+            "parameters": {
+                "column_sort": "date"
+            }
         }
     }
 ```

--- a/docs/freqai-parameter-table.md
+++ b/docs/freqai-parameter-table.md
@@ -23,6 +23,7 @@ Mandatory parameters are marked as **Required** and have to be set in one of the
 | `data_kitchen_thread_count` | <br> Designate the number of threads you want to use for data processing (outlier methods, normalization, etc.). This has no impact on the number of threads used for training. If user does not set it (default), FreqAI will use max number of threads - 2 (leaving 1 physical core available for Freqtrade bot and FreqUI) <br> **Datatype:** Positive integer.
 | `activate_tensorboard` | <br> Indicate whether or not to activate tensorboard for the tensorboard enabled modules (currently Reinforcment Learning, XGBoost, Catboost, and PyTorch). Tensorboard needs Torch installed, which means you will need the torch/RL docker image or you need to answer "yes" to the install question about whether or not you wish to install Torch. <br> **Datatype:** Boolean. <br> Default: `True`.
 | `wait_for_training_iteration_on_reload` | <br> When using /reload or ctrl-c, wait for the current training iteration to finish before completing graceful shutdown. If set to `False`, FreqAI will break the current training iteration, allowing you to shutdown gracefully more quickly, but you will lose your current training iteration. <br> **Datatype:** Boolean. <br> Default: `True`.
+| `feature_engineering` | Enable an optional feature engineering pipeline that runs before the train/test split. Currently supports the `tsfresh` and `featuretools` libraries. <br> **Datatype:** Dictionary.
 
 ### Feature parameters
 

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -1142,6 +1142,25 @@ CONF_SCHEMA = {
                     "type": "boolean",
                     "default": False,
                 },
+                "feature_engineering": {
+                    "description": (
+                        "Optional feature engineering pipeline applied before the train/test "
+                        "split. Supports the 'tsfresh' and 'featuretools' libraries."
+                    ),
+                    "type": "object",
+                    "properties": {
+                        "library": {
+                            "description": "Library to use for feature engineering.",
+                            "type": "string",
+                            "enum": ["tsfresh", "featuretools"],
+                        },
+                        "parameters": {
+                            "description": "Parameters forwarded to the selected library.",
+                            "type": "object",
+                            "default": {},
+                        },
+                    },
+                },
                 "feature_parameters": {
                     "description": "The parameters used to engineer the feature set",
                     "type": "object",

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -135,6 +135,9 @@ class FreqaiDataKitchen:
         :param filtered_dataframe: cleaned dataframe ready to be split.
         :param labels: cleaned labels ready to be split.
         """
+        # Apply optional feature engineering pipeline before splitting the data
+        filtered_dataframe = self._apply_feature_engineering(filtered_dataframe)
+
         feat_dict = self.freqai_config["feature_parameters"]
 
         if "shuffle" not in self.freqai_config["data_split_parameters"]:
@@ -318,6 +321,47 @@ class FreqaiDataKitchen:
         }
 
         return self.data_dictionary
+
+    def _apply_feature_engineering(self, dataframe: DataFrame) -> DataFrame:
+        """Apply optional tsfresh/featuretools feature engineering pipeline."""
+
+        fe_cfg = self.freqai_config.get("feature_engineering")
+        if not fe_cfg:
+            return dataframe
+
+        library = fe_cfg.get("library", "").lower()
+        params = fe_cfg.get("parameters", {})
+
+        if library == "tsfresh":
+            try:
+                from tsfresh import extract_features
+            except Exception as exc:  # pragma: no cover - ImportError or others
+                raise OperationalException(
+                    "tsfresh is required for feature_engineering 'tsfresh'"  # noqa: TRY003
+                ) from exc
+            df_copy = dataframe.copy()
+            df_copy["_id"] = 0
+            extracted = extract_features(
+                df_copy,
+                column_id="_id",
+                column_sort=params.get("column_sort", "date"),
+                **params.get("tsfresh_kwargs", {}),
+            )
+            dataframe = pd.concat([dataframe.reset_index(drop=True), extracted.reset_index(drop=True)], axis=1)
+        elif library == "featuretools":
+            try:
+                import featuretools as ft
+            except Exception as exc:  # pragma: no cover
+                raise OperationalException(
+                    "featuretools is required for feature_engineering 'featuretools'"  # noqa: TRY003
+                ) from exc
+            es = ft.EntitySet(id="data")
+            df_copy = dataframe.reset_index(drop=True)
+            es.add_dataframe(dataframe_name="df", dataframe=df_copy, index="index")
+            feature_matrix, _ = ft.dfs(entityset=es, target_dataframe_name="df", **params)
+            dataframe = feature_matrix
+
+        return dataframe
 
     def split_timerange(
         self, tr: str, train_split: int = 28, bt_split: float = 7

--- a/tests/freqai/test_freqai_datakitchen.py
+++ b/tests/freqai/test_freqai_datakitchen.py
@@ -106,6 +106,35 @@ def test_make_train_test_datasets(mocker, freqai_conf):
     assert len(data_dictionary["train_features"].index) == 1916
 
 
+def test_make_train_test_datasets_with_feature_engineering(mocker, freqai_conf):
+    freqai_conf["freqai"]["feature_engineering"] = {"library": "tsfresh"}
+
+    import sys
+    import types
+
+    dummy = types.SimpleNamespace()
+
+    def fake_extract_features(df, column_id, column_sort, **kwargs):
+        return pd.DataFrame({"extra_feat": df["close"]})
+
+    dummy.extract_features = fake_extract_features
+    mocker.patch.dict(sys.modules, {"tsfresh": dummy})
+
+    dk = FreqaiDataKitchen(freqai_conf)
+
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2020", periods=10, freq="1h"),
+            "close": range(10),
+        }
+    )
+    labels = pd.DataFrame({"label": range(10)})
+
+    data_dictionary = dk.make_train_test_datasets(df, labels)
+
+    assert "extra_feat" in data_dictionary["train_features"].columns
+
+
 @pytest.mark.parametrize("model", ["LightGBMRegressor"])
 def test_get_full_model_path(mocker, freqai_conf, model):
     freqai_conf.update({"freqaimodel": model})


### PR DESCRIPTION
## Summary
- add optional `tsfresh`/`featuretools` feature-engineering pipeline in `FreqaiDataKitchen`
- document and expose new `freqai.feature_engineering` configuration
- test feature engineering activation

## Testing
- `pytest tests/freqai/test_freqai_datakitchen.py::test_make_train_test_datasets_with_feature_engineering -q`
- `pytest tests/freqai/test_freqai_datakitchen.py::test_make_train_test_datasets -q` *(fails: Missing LightGBM dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a06d7b187c83269938e4d0a4d1e5a2