### PR TITLE
feat(freqai): drop low importance features

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -245,6 +245,24 @@ Example::
             "hyperparameters": {"GBM": {}, "NN_TORCH": {}}
         }
     }
+    
+```
+
+#### Feature importance threshold
+
+AutoGluon models can optionally remove weak features after an initial training
+round.  Set ``model_training_parameters['fi_threshold']`` to a positive value to
+enable this behaviour.  After the first ``predictor.fit`` call FreqAI evaluates
+feature importances via ``predictor.feature_importance()`` and drops all
+features with an importance below the threshold before re-training the model.
+
+Example::
+
+    "freqai": {
+        "model_training_parameters": {
+            "fi_threshold": 0.01
+        }
+    }
 
 ### AutoGluon TimeSeries training parameters
 

--- a/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTabularRegressor.py
@@ -71,6 +71,7 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
         num_bag_folds = train_params.pop("num_bag_folds", None)
         num_bag_sets = train_params.pop("num_bag_sets", None)
         time_limit = train_params.pop("time_limit", None)
+        fi_threshold = train_params.pop("fi_threshold", None)
 
         predictor = predictor.fit(
             train,
@@ -83,4 +84,39 @@ class AutoGluonTabularRegressor(BaseRegressionModel):
             time_limit=time_limit,
             **train_params,
         )
+
+        if fi_threshold is not None:
+            fi_df = predictor.feature_importance(train)
+            # AutoGluon returns a DataFrame indexed by feature name
+            importances = fi_df["importance"] if "importance" in fi_df else fi_df.iloc[:, 0]
+            drop_list = importances[importances < fi_threshold].index.tolist()
+            if drop_list:
+                logger.info(
+                    "Dropping features below fi_threshold %s: %s",
+                    fi_threshold,
+                    drop_list,
+                )
+                dk.training_features_list = [
+                    f for f in dk.training_features_list if f not in drop_list
+                ]
+                train = train.drop(columns=drop_list)
+                data_dictionary["train_features"] = train
+                if tuning_data is not None:
+                    tuning_data = tuning_data.drop(columns=drop_list)
+                    data_dictionary["test_features"] = tuning_data
+                predictor = TabularPredictor(
+                    label=dk.label_list[0], problem_type="regression"
+                )
+                predictor = predictor.fit(
+                    train,
+                    tuning_data=tuning_data,
+                    hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+                    presets=presets,
+                    eval_metric=eval_metric,
+                    num_bag_folds=num_bag_folds,
+                    num_bag_sets=num_bag_sets,
+                    time_limit=time_limit,
+                    **train_params,
+                )
+
         return predictor

--- a/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
@@ -35,7 +35,9 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
                 "'pip install autogluon.timeseries' to use AutoGluonTimeSeriesPredictor."
             ) from e
 
-        freq = self.model_training_parameters.pop("freq", None)
+        train_params = self.model_training_parameters.copy()
+        freq = train_params.pop("freq", None)
+        fi_threshold = train_params.pop("fi_threshold", None)
 
         train = data_dictionary["train_features"].copy()
         train["target"] = data_dictionary["train_labels"].squeeze()
@@ -53,6 +55,7 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
         )
 
         tuning_ts = None
+        test = None
         if self.freqai_info.get("data_split_parameters", {}).get("test_size", 0.1) != 0:
             test = data_dictionary["test_features"].copy()
             test["target"] = data_dictionary["test_labels"].squeeze()
@@ -76,9 +79,49 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
             target="target",
             freq=freq,
         )
-        predictor = predictor.fit(
-            self.train_ts, tuning_data=tuning_ts, **self.model_training_parameters
-        )
+        predictor = predictor.fit(self.train_ts, tuning_data=tuning_ts, **train_params)
+
+        if fi_threshold is not None:
+            fi_df = predictor.feature_importance(self.train_ts)
+            importances = fi_df["importance"] if "importance" in fi_df else fi_df.iloc[:, 0]
+            drop_list = importances[importances < fi_threshold].index.tolist()
+            if drop_list:
+                logger.info(
+                    "Dropping features below fi_threshold %s: %s",
+                    fi_threshold,
+                    drop_list,
+                )
+                dk.training_features_list = [
+                    f for f in dk.training_features_list if f not in drop_list
+                ]
+                train = train.drop(columns=drop_list)
+                data_dictionary["train_features"] = train.drop(
+                    columns=["target", "item_id", "timestamp"]
+                )
+                self.train_ts = TimeSeriesDataFrame.from_data_frame(
+                    train,
+                    id_column="item_id",
+                    timestamp_column="timestamp",
+                )
+                if test is not None:
+                    test = test.drop(columns=drop_list)
+                    data_dictionary["test_features"] = test.drop(
+                        columns=["target", "item_id", "timestamp"]
+                    )
+                    tuning_ts = TimeSeriesDataFrame.from_data_frame(
+                        test,
+                        id_column="item_id",
+                        timestamp_column="timestamp",
+                    )
+                predictor = TimeSeriesPredictor(
+                    prediction_length=prediction_length,
+                    target="target",
+                    freq=freq,
+                )
+                predictor = predictor.fit(
+                    self.train_ts, tuning_data=tuning_ts, **train_params
+                )
+
         return predictor
 
     def predict(

--- a/tests/freqai/test_freqai_autogluon_strategy.py
+++ b/tests/freqai/test_freqai_autogluon_strategy.py
@@ -127,3 +127,55 @@ def test_freqai_autogluon_strategy_model_creation(mocker, freqai_conf):
     for col in ["enter_long", "exit_long", "enter_short", "exit_short"]:
         assert col in df.columns
         assert df[col].notna().any()
+
+
+def test_autogluon_tabular_fi_threshold(mocker, freqai_conf):
+    import sys
+    import types
+    import pandas as pd
+
+    freqai_conf["freqai"]["model_training_parameters"]["fi_threshold"] = 0.05
+    freqai_conf["freqai"]["data_split_parameters"]["test_size"] = 0
+
+    fit_calls: list[list[str]] = []
+
+    class DummyPredictor:
+        def fit(self, train, tuning_data=None, **kwargs):
+            fit_calls.append(list(train.columns))
+            return self
+
+        def feature_importance(self, data):
+            return pd.DataFrame(
+                {"importance": [0.2, 0.01, 0.3]}, index=["f1", "f2", "f3"]
+            )
+
+    dummy_module = types.ModuleType("autogluon.tabular")
+    dummy_module.TabularPredictor = lambda label, problem_type: DummyPredictor()
+    dummy_autogluon = types.ModuleType("autogluon")
+    dummy_autogluon.tabular = dummy_module
+    mocker.patch.dict(sys.modules, {
+        "autogluon": dummy_autogluon,
+        "autogluon.tabular": dummy_module,
+    })
+
+    from freqtrade.freqai.prediction_models.AutoGluonTabularRegressor import (
+        AutoGluonTabularRegressor,
+    )
+    from types import SimpleNamespace
+
+    model = AutoGluonTabularRegressor(freqai_conf)
+
+    data_dictionary = {
+        "train_features": pd.DataFrame(
+            {"f1": [1, 2], "f2": [3, 4], "f3": [5, 6]}
+        ),
+        "train_labels": pd.DataFrame({"label": [1, 0]}),
+        "test_features": pd.DataFrame(),
+        "test_labels": pd.DataFrame(),
+    }
+    dk = SimpleNamespace(label_list=["label"], training_features_list=["f1", "f2", "f3"])
+
+    model.fit(data_dictionary, dk)
+
+    assert fit_calls == [["f1", "f2", "f3", "label"], ["f1", "f3", "label"]]
+    assert dk.training_features_list == ["f1", "f3"]


### PR DESCRIPTION
## Summary
- drop low-importance columns using AutoGluon `feature_importance` and retrain if needed
- document `fi_threshold` option for FreqAI

## Testing
- `pytest tests/freqai/test_freqai_autogluon_strategy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06d7c72248326a8a3e43d1ae8550b