### PR TITLE
feat: add AutoGluon TimeSeries predictor

### DIFF
--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -250,14 +250,18 @@ Example::
 
 The ``AutoGluonTimeSeriesPredictor`` wraps AutoGluon's
 ``TimeSeriesPredictor`` and automatically converts the data into a
-``TimeSeriesDataFrame``.  In addition to the common settings above, it accepts
-``freq`` to specify the frequency of the time index.
+``TimeSeriesDataFrame``. In addition to the common settings above, it accepts
+``freq`` to specify the frequency of the time index, ``prediction_length`` to
+control the forecast horizon, and ``known_covariates_names`` to explicitly
+define known covariate columns.
 
 Example::
 
     "freqai": {
         "model_training_parameters": {
             "freq": "1h",
+            "prediction_length": 24,
+            "known_covariates_names": ["feat1", "feat2"],
             "time_limit": 600
         }
     }

--- a/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
+++ b/freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py
@@ -36,6 +36,13 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
             ) from e
 
         freq = self.model_training_parameters.pop("freq", None)
+        prediction_length = self.model_training_parameters.pop(
+            "prediction_length",
+            self.freqai_info.get("feature_parameters", {}).get("label_period_candles", 1),
+        )
+        known_covariates_names = self.model_training_parameters.pop(
+            "known_covariates_names", dk.training_features_list
+        )
 
         train = data_dictionary["train_features"].copy()
         train["target"] = data_dictionary["train_labels"].squeeze()
@@ -68,14 +75,13 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
                 timestamp_column="timestamp",
             )
 
-        prediction_length = self.freqai_info.get("feature_parameters", {}).get(
-            "label_period_candles", 1
-        )
         predictor = TimeSeriesPredictor(
             prediction_length=prediction_length,
             target="target",
             freq=freq,
+            known_covariates_names=known_covariates_names,
         )
+        self.prediction_length = prediction_length
         predictor = predictor.fit(
             self.train_ts, tuning_data=tuning_ts, **self.model_training_parameters
         )
@@ -113,7 +119,9 @@ class AutoGluonTimeSeriesPredictor(BaseRegressionModel):
         )
 
         forecasts = self.model.predict(
-            self.train_ts, known_covariates=ts, prediction_length=len(ts)
+            self.train_ts,
+            known_covariates=ts,
+            prediction_length=self.prediction_length,
         )
         pred_df = forecasts.to_pandas().reset_index(level=0, drop=True)
         if "mean" in pred_df.columns:

--- a/freqtrade/templates/FreqaiAutoGluonStrategy.py
+++ b/freqtrade/templates/FreqaiAutoGluonStrategy.py
@@ -5,8 +5,8 @@ import talib.abstract as ta
 from pandas import DataFrame
 from technical import qtpylib
 
-from freqtrade.freqai.prediction_models.AutoGluonTabularRegressor import (  # noqa: F401
-    AutoGluonTabularRegressor,
+from freqtrade.freqai.prediction_models.AutoGluonTimeSeriesPredictor import (  # noqa: F401
+    AutoGluonTimeSeriesPredictor,
 )
 from freqtrade.strategy import IStrategy
 
@@ -16,12 +16,12 @@ logger = logging.getLogger(__name__)
 
 class FreqaiAutoGluonStrategy(IStrategy):
     """
-    Example strategy demonstrating how to use AutoGluonTabularRegressor with FreqAI.
+    Example strategy demonstrating how to use AutoGluonTimeSeriesPredictor with FreqAI.
 
     Launch with:
 
         freqtrade trade --config config_examples/config_freqai_autogluon.example.json \
-            --strategy FreqaiAutoGluonStrategy --freqaimodel AutoGluonTabularRegressor \
+            --strategy FreqaiAutoGluonStrategy --freqaimodel AutoGluonTimeSeriesPredictor \
             --strategy-path freqtrade/templates
 
     Warning! This is a showcase of functionality,


### PR DESCRIPTION
## Summary
- expose freq, prediction_length and known_covariates_names for AutoGluon TimeSeries predictor
- reference new predictor from FreqaiAutoGluonStrategy template
- document new AutoGluon TimeSeries options

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/AutoGluonTimeSeriesPredictor.py freqtrade/templates/FreqaiAutoGluonStrategy.py docs/freqai-configuration.md`
- `pytest tests/freqai/test_freqai_autogluon_timeseries_strategy.py::test_freqai_autogluon_timeseries_strategy_backtest tests/freqai/test_freqai_autogluon_strategy.py::test_freqai_autogluon_strategy_backtest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06d72909c83268f0f47baac11cf4a