### PR TITLE
feat(freqai): add walkforward window splits

### DIFF
--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -84,6 +84,8 @@ class FreqaiDataKitchen:
         self.feature_pipeline = Pipeline()
         self.label_pipeline = Pipeline()
         self.DI_values: npt.NDArray = np.array([])
+        self.walkforward_performance: list[float] = []
+        self.aggregated_performance: float = 0.0
 
         if not self.live:
             self.full_path = self.get_full_models_path(self.config)
@@ -92,11 +94,13 @@ class FreqaiDataKitchen:
                 self.full_timerange = self.create_fulltimerange(
                     self.config["timerange"], self.freqai_config.get("train_period_days", 0)
                 )
-                (self.training_timeranges, self.backtesting_timeranges) = self.split_timerange(
+                tr_splits = self.split_timerange(
                     self.full_timerange,
                     config["freqai"]["train_period_days"],
                     config["freqai"]["backtest_period_days"],
                 )
+                self.training_timeranges = [tr for tr, _ in tr_splits]
+                self.backtesting_timeranges = [bt for _, bt in tr_splits]
 
         self.data["extra_returns_per_train"] = self.freqai_config.get("extra_returns_per_train", {})
         if not self.freqai_config.get("data_kitchen_thread_count", 0):
@@ -321,14 +325,13 @@ class FreqaiDataKitchen:
 
     def split_timerange(
         self, tr: str, train_split: int = 28, bt_split: float = 7
-    ) -> tuple[list, list]:
+    ) -> list[tuple[TimeRange, TimeRange]]:
         """
-        Function which takes a single time range (tr) and splits it
-        into sub timeranges to train and backtest on based on user input
-        tr: str, full timerange to train on
-        train_split: the period length for the each training (days). Specified in user
-        configuration file
-        bt_split: the backtesting length (days). Specified in user configuration file
+        Split a full timerange into multiple training/backtesting timerange tuples.
+        :param tr: Full timerange to train on
+        :param train_split: Training window length in days
+        :param bt_split: Backtesting window length in days
+        :return: List of (train_timerange, backtest_timerange) tuples
         """
 
         if not isinstance(train_split, int) or train_split < 1:
@@ -345,10 +348,7 @@ class FreqaiDataKitchen:
         timerange_train = copy.deepcopy(full_timerange)
         timerange_backtest = copy.deepcopy(full_timerange)
 
-        tr_training_list = []
-        tr_backtesting_list = []
-        tr_training_list_timerange = []
-        tr_backtesting_list_timerange = []
+        splits: list[tuple[TimeRange, TimeRange]] = []
         first = True
 
         while True:
@@ -357,8 +357,7 @@ class FreqaiDataKitchen:
             timerange_train.stopts = timerange_train.startts + train_period_days
 
             first = False
-            tr_training_list.append(timerange_train.timerange_str)
-            tr_training_list_timerange.append(copy.deepcopy(timerange_train))
+            train_tr = copy.deepcopy(timerange_train)
 
             # associated backtest period
             timerange_backtest.startts = timerange_train.stopts
@@ -367,16 +366,15 @@ class FreqaiDataKitchen:
             if timerange_backtest.stopts > config_timerange.stopts:
                 timerange_backtest.stopts = config_timerange.stopts
 
-            tr_backtesting_list.append(timerange_backtest.timerange_str)
-            tr_backtesting_list_timerange.append(copy.deepcopy(timerange_backtest))
+            backtest_tr = copy.deepcopy(timerange_backtest)
+            splits.append((train_tr, backtest_tr))
 
             # ensure we are predicting on exactly same amount of data as requested by user defined
             #  --timerange
             if timerange_backtest.stopts == config_timerange.stopts:
                 break
 
-        # print(tr_training_list, tr_backtesting_list)
-        return tr_training_list_timerange, tr_backtesting_list_timerange
+        return splits
 
     def slice_dataframe(self, timerange: TimeRange, df: DataFrame) -> DataFrame:
         """

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -394,7 +394,17 @@ class IFreqaiModel(ABC):
                 dk.append_predictions(append_df)
                 dk.save_backtesting_prediction(append_df)
 
+                actual = dataframe_backtest[dk.label_list].to_numpy()
+                predicted = pred_df[dk.label_list].to_numpy()
+                dk.walkforward_performance.append(
+                    float(np.nanmean((actual - predicted) ** 2))
+                )
+
         self.backtesting_fit_live_predictions(dk)
+        if dk.walkforward_performance:
+            dk.aggregated_performance = float(
+                np.nanmean(dk.walkforward_performance)
+            )
         dk.fill_predictions(dataframe)
 
         return dk

--- a/tests/freqai/test_freqai_datakitchen.py
+++ b/tests/freqai/test_freqai_datakitchen.py
@@ -55,8 +55,8 @@ def test_split_timerange(
 ):
     freqai_conf.update({"timerange": "20220101-20220401"})
     dk = get_patched_data_kitchen(mocker, freqai_conf)
-    tr_list, bt_list = dk.split_timerange(timerange, train_period_days, backtest_period_days)
-    assert len(tr_list) == len(bt_list) == expected_result
+    splits = dk.split_timerange(timerange, train_period_days, backtest_period_days)
+    assert len(splits) == expected_result
 
     with pytest.raises(
         OperationalException, match=r"train_period_days must be an integer greater than 0."

--- a/tests/freqai/test_freqai_walkforward.py
+++ b/tests/freqai/test_freqai_walkforward.py
@@ -1,0 +1,40 @@
+import numpy as np
+from freqtrade.configuration import TimeRange
+from freqtrade.data.dataprovider import DataProvider
+from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
+from tests.freqai.conftest import get_patched_freqai_strategy
+from tests.conftest import get_patched_exchange
+
+
+def test_walkforward_performance_aggregation(freqai_conf, mocker):
+    freqai_conf["timerange"] = "20180115-20180125"
+    freqai_conf["freqai"]["train_period_days"] = 2
+    freqai_conf["freqai"]["backtest_period_days"] = 1
+
+    strategy = get_patched_freqai_strategy(mocker, freqai_conf)
+    exchange = get_patched_exchange(mocker, freqai_conf)
+    strategy.dp = DataProvider(freqai_conf, exchange)
+    strategy.freqai_info = freqai_conf.get("freqai", {})
+    freqai = strategy.freqai
+    freqai.live = False
+    dk = FreqaiDataKitchen(freqai_conf)
+    freqai.dk = dk
+
+    timerange = TimeRange.parse_timerange(dk.full_timerange)
+    freqai.dd.load_all_pair_histories(timerange, dk)
+    corr_df, base_df = freqai.dd.get_base_and_corr_dataframes(timerange, "ADA/BTC", dk)
+    dataframe = dk.use_strategy_to_populate_indicators(strategy, corr_df, base_df, "ADA/BTC")
+
+    mocker.patch.object(freqai, "train", lambda df, pair, dk, **kw: None)
+
+    def _predict(df, dk, **kw):
+        dk.DI_values = np.zeros(len(df))
+        return df[dk.label_list].copy(), np.ones(len(df), dtype=int)
+
+    mocker.patch.object(freqai, "predict", _predict)
+
+    freqai.start_backtesting(dataframe, {"pair": "ADA/BTC"}, dk, strategy)
+
+    assert len(dk.training_timeranges) >= 2
+    assert len(dk.walkforward_performance) == len(dk.backtesting_timeranges) >= 2
+    assert dk.aggregated_performance == 0.0


### PR DESCRIPTION
## Summary
- extend `split_timerange` to produce sequential train/backtest pairs
- capture per-window and aggregated walk-forward performance during backtests
- cover walk-forward splitting with integration test

## Testing
- `pytest tests/freqai/test_freqai_datakitchen.py::test_split_timerange -q`
- `pytest tests/freqai/test_freqai_walkforward.py::test_walkforward_performance_aggregation -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06d7fcf148326b19eab55f52c5198