### PR TITLE
Add regime detection to FreqAI

### DIFF
--- a/config_examples/config_freqai.example.json
+++ b/config_examples/config_freqai.example.json
@@ -80,7 +80,11 @@
             "test_size": 0.33,
             "random_state": 1
         },
-        "model_training_parameters": {}
+        "model_training_parameters": {},
+        "regime_detection": {
+            "enabled": true,
+            "n_clusters": 2
+        }
     },
     "bot_name": "",
     "force_entry_enable": true,

--- a/docs/freqai-configuration.md
+++ b/docs/freqai-configuration.md
@@ -35,6 +35,22 @@ A full example config is available in `config_examples/config_freqai.example.jso
 !!! Note
     The `identifier` is commonly overlooked by newcomers, however, this value plays an important role in your configuration. This value is a unique ID that you choose to describe one of your runs. Keeping it the same allows you to maintain crash resilience as well as faster backtesting. As soon as you want to try a new run (new features, new model, etc.), you should change this value (or delete the `user_data/models/unique-id` folder. More details available in the [parameter table](freqai-parameter-table.md#feature-parameters).
 
+### Regime detection
+
+FreqAI can train dedicated models for different market regimes detected through clustering. Activate the feature by adding:
+
+```json
+"freqai": {
+    "enabled": true,
+    "regime_detection": {
+        "enabled": true,
+        "n_clusters": 2
+    }
+}
+```
+
+When enabled, FreqAI segments the data using simple volatility and trend indicators and routes training and inference to the model of the detected regime.
+
 ## Building a FreqAI strategy
 
 The FreqAI strategy requires including the following lines of code in the standard [Freqtrade strategy](strategy-customization.md):

--- a/freqtrade/freqai/data_kitchen.py
+++ b/freqtrade/freqai/data_kitchen.py
@@ -20,6 +20,7 @@ from freqtrade.constants import DOCS_LINK, ORDERFLOW_ADDED_COLUMNS, Config
 from freqtrade.data.converter import reduce_dataframe_footprint
 from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import timeframe_to_seconds
+from freqtrade.freqai.regime.regime_detector import RegimeDetector
 from freqtrade.strategy import merge_informative_pair
 from freqtrade.strategy.interface import IStrategy
 
@@ -84,6 +85,12 @@ class FreqaiDataKitchen:
         self.feature_pipeline = Pipeline()
         self.label_pipeline = Pipeline()
         self.DI_values: npt.NDArray = np.array([])
+        self.regime_config: dict[str, Any] = self.freqai_config.get("regime_detection", {})
+        self.regime_detector: RegimeDetector | None = None
+        self.current_regime: int = 0
+        if self.regime_config.get("enabled", False):
+            rd_params = {k: v for k, v in self.regime_config.items() if k != "enabled"}
+            self.regime_detector = RegimeDetector(**rd_params)
 
         if not self.live:
             self.full_path = self.get_full_models_path(self.config)
@@ -125,6 +132,32 @@ class FreqaiDataKitchen:
 
         return
 
+    def detect_regime(self, dataframe: DataFrame) -> int:
+        """Detect and store the current market regime for ``dataframe``."""
+        if not self.regime_config.get("enabled", False) or self.regime_detector is None:
+            self.current_regime = 0
+            return self.current_regime
+        regimes = self.regime_detector.detect(dataframe)
+        if not regimes.empty:
+            self.current_regime = int(regimes.iloc[-1])
+        else:
+            self.current_regime = 0
+        return self.current_regime
+
+    def _apply_regime_filter(
+        self, filtered_dataframe: DataFrame, labels: DataFrame
+    ) -> tuple[DataFrame, DataFrame]:
+        """Filter dataframe and labels to the current regime if enabled."""
+        if not self.regime_config.get("enabled", False) or self.regime_detector is None:
+            return filtered_dataframe, labels
+        regimes = self.regime_detector.detect(filtered_dataframe)
+        if not regimes.empty:
+            if self.current_regime is None:
+                self.current_regime = int(regimes.iloc[-1])
+            mask = regimes == self.current_regime
+            return filtered_dataframe.loc[mask], labels.loc[mask]
+        return filtered_dataframe, labels
+
     def make_train_test_datasets(
         self, filtered_dataframe: DataFrame, labels: DataFrame
     ) -> dict[Any, Any]:
@@ -139,6 +172,8 @@ class FreqaiDataKitchen:
 
         if "shuffle" not in self.freqai_config["data_split_parameters"]:
             self.freqai_config["data_split_parameters"].update({"shuffle": False})
+
+        filtered_dataframe, labels = self._apply_regime_filter(filtered_dataframe, labels)
 
         weights: npt.ArrayLike
         if feat_dict.get("weight_factor", 0) > 0:
@@ -589,9 +624,14 @@ class FreqaiDataKitchen:
 
     def set_new_model_names(self, pair: str, timestamp_id: int):
         coin, _ = pair.split("/")
-        self.data_path = Path(self.full_path / f"sub-train-{pair.split('/')[0]}_{timestamp_id}")
+        regime_suffix = (
+            f"_r{self.current_regime}" if self.regime_config.get("enabled", False) else ""
+        )
+        self.data_path = Path(
+            self.full_path / f"sub-train-{pair.split('/')[0]}_{timestamp_id}{regime_suffix}"
+        )
 
-        self.model_filename = f"cb_{coin.lower()}_{timestamp_id}"
+        self.model_filename = f"cb_{coin.lower()}_{timestamp_id}{regime_suffix}"
 
     def set_all_pairs(self) -> None:
         self.all_pairs = copy.deepcopy(

--- a/freqtrade/freqai/freqai_interface.py
+++ b/freqtrade/freqai/freqai_interface.py
@@ -317,7 +317,8 @@ class IFreqaiModel(ABC):
             timestamp_model_id = int(tr_train.stopts)
             if dk.backtest_live_models:
                 timestamp_model_id = int(tr_backtest.startts)
-
+            df_regime = dataframe.loc[dataframe["date"] < tr_train.stopdt, :]
+            dk.detect_regime(df_regime)
             dk.set_paths(pair, timestamp_model_id)
 
             dk.set_new_model_names(pair, timestamp_model_id)
@@ -389,6 +390,7 @@ class IFreqaiModel(ABC):
                 else:
                     self.model = self.dd.load_data(pair, dk)
 
+                dk.detect_regime(dataframe_backtest)
                 pred_df, do_preds = self.predict(dataframe_backtest, dk)
                 append_df = dk.get_predictions_to_append(pred_df, do_preds, dataframe_backtest)
                 dk.append_predictions(append_df)
@@ -477,6 +479,7 @@ class IFreqaiModel(ABC):
         if pair not in self.dd.model_return_values:
             # first predictions are made on entire historical candle set coming from strategy. This
             # allows FreqUI to show full return values.
+            dk.detect_regime(dataframe)
             pred_df, do_preds = self.predict(dataframe, dk)
             if pair not in self.dd.historic_predictions:
                 self.set_initial_historic_predictions(pred_df, dk, pair, dataframe)
@@ -496,7 +499,9 @@ class IFreqaiModel(ABC):
         else:
             # remaining predictions are made only on the most recent candles for performance and
             # historical accuracy reasons.
-            pred_df, do_preds = self.predict(dataframe.iloc[-self.CONV_WIDTH :], dk, first=False)
+            recent_df = dataframe.iloc[-self.CONV_WIDTH :]
+            dk.detect_regime(recent_df)
+            pred_df, do_preds = self.predict(recent_df, dk, first=False)
 
         if self.freqai_info.get("fit_live_predictions_candles", 0) and self.live:
             self.fit_live_predictions(dk, pair)
@@ -625,6 +630,8 @@ class IFreqaiModel(ABC):
         # find the features indicated by strategy and store in datakitchen
         dk.find_features(unfiltered_dataframe)
         dk.find_labels(unfiltered_dataframe)
+
+        dk.detect_regime(unfiltered_dataframe)
 
         self.tb_logger = get_tb_logger(self.dd.model_type, dk.data_path, self.activate_tensorboard)
         model = self.train(unfiltered_dataframe, pair, dk)

--- a/freqtrade/freqai/regime/__init__.py
+++ b/freqtrade/freqai/regime/__init__.py
@@ -1,0 +1,1 @@
+"""Regime detection utilities for FreqAI."""

--- a/freqtrade/freqai/regime/regime_detector.py
+++ b/freqtrade/freqai/regime/regime_detector.py
@@ -1,0 +1,46 @@
+"""Tools to detect market regimes using clustering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+from pandas import DataFrame, Series
+from sklearn.cluster import KMeans
+
+
+@dataclass
+class RegimeDetector:
+    """Simple regime detector based on KMeans clustering.
+
+    The detector extracts basic volatility and trend features from closing prices
+    before applying a ``KMeans`` clustering algorithm.  The resulting cluster label
+    represents the market regime.
+    """
+
+    n_clusters: int = 2
+    volatility_window: int = 20
+    trend_window: int = 50
+    random_state: int = 0
+
+    def _prepare(self, df: DataFrame) -> DataFrame:
+        """Compute volatility and trend features from a dataframe."""
+        price = df["close"]
+        # Volatility estimated by rolling standard deviation of returns
+        volatility = price.pct_change().rolling(self.volatility_window).std()
+        # Trend estimated by percent change of a moving average
+        trend = price.rolling(self.trend_window).mean().pct_change()
+        feats = pd.concat([volatility, trend], axis=1)
+        feats.columns = ["volatility", "trend"]
+        return feats.dropna()
+
+    def detect(self, df: DataFrame) -> Series:
+        """Return regime labels for each row of ``df``."""
+        feats = self._prepare(df)
+        if feats.empty:
+            return pd.Series([0] * len(df), index=df.index)
+        model = KMeans(n_clusters=self.n_clusters, n_init="auto", random_state=self.random_state)
+        labels = model.fit_predict(feats)
+        series = pd.Series(labels, index=feats.index)
+        # Forward fill to align to original dataframe length
+        return series.reindex(df.index, method="ffill").fillna(0).astype(int)

--- a/tests/freqai/test_regime_detector.py
+++ b/tests/freqai/test_regime_detector.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+from freqtrade.freqai.regime.regime_detector import RegimeDetector
+
+
+def test_regime_detector_basic():
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+    detector = RegimeDetector(n_clusters=2, volatility_window=2, trend_window=2)
+    regimes = detector.detect(df)
+    assert len(regimes) == len(df)
+    # ensure labels are between 0 and n_clusters - 1
+    assert regimes.min() >= 0
+    assert regimes.max() < 2


### PR DESCRIPTION
## Summary
- add KMeans based regime detector
- route model training and inference by market regime
- document `freqai.regime_detection` configuration and example

## Testing
- `pre-commit run --files freqtrade/freqai/regime/__init__.py freqtrade/freqai/regime/regime_detector.py freqtrade/freqai/data_kitchen.py freqtrade/freqai/freqai_interface.py config_examples/config_freqai.example.json docs/freqai-configuration.md tests/freqai/test_regime_detector.py`
- `pytest tests/freqai/test_regime_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_68a06d7cce348326a73432a2bf3d1ead